### PR TITLE
Resolve issue tied to missing issue IDs during issue creation

### DIFF
--- a/linear-assistant-ts/baml_src/linear.baml
+++ b/linear-assistant-ts/baml_src/linear.baml
@@ -14,7 +14,7 @@ class DoneForNow {
 
     If you don't have a link to the issue, you can use a search query to find it.
 
-    Linear urls look like https://linear.app/humanlayer/issue/ISSUE_ID/ISSUE_TITLE
+    Linear URLs look like https://linear.app/humanlayer/issue/ISSUE_ID/ISSUE_TITLE
   "#)
 }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/humanlayer/humanlayer/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:

-->

**What I did**

* Used the Linear SDK a bit differently, but mostly the same to create an issue.
* Parallelized some of the calls we make when the system fires up.

<!--
A succinct description of the user-facing changes, at most 2-3 bullet points.
Less about the code changes that happened, more about the outcomes this work drives
-->

**How I did it**

First a quick thing about JavaScript's "Lazy Evaluation with Getters" trick. You can, with JavaScript, trigger behavior when an attribute is accessed on a class. Here's an example:

```javascript
class Issue {
  constructor(id) {
    this.id = id;
    this._details = null; // Not loaded initially
  }

  // Getter triggers data fetching when accessed
  get details() {
    if (!this._details) {
      console.log("Fetching full issue details...");
      this._details = this.fetchFullIssue();
    }
    return this._details;
  }

  // Simulated API call (would normally be async)
  fetchFullIssue() {
    return {
      id: this.id,
      title: "Fix login bug",
      url: `https://linear.app/issues/${this.id}`,
    };
  }
}

// Example usage
const issue = new Issue(123);

console.log("Before accessing details:", issue.id); // Only shows id
console.log("Accessing details:", issue.details);  // Fetches data and prints it
console.log("Accessing details again:", issue.details);  // Uses cached data
```

In this example, you'll notice some neat behavior start when we call `issue.details`. This is also slightly insane.

In our case when we're using the Linear SDK, I'm pretty sure it features the same trick, so when you access `issue` on a returned payload during creation, you get a fully populated entity (because presumably a second request goes out to the Linear API). 

This bit of Linear source tipped me off to this:

![CleanShot 2025-02-19 at 16 16 11@2x](https://github.com/user-attachments/assets/c4c6dd59-d0a5-4f0c-a319-b02c6ac7882f)


<!--
Describe the work you did, tests you ran, changes you made, etc
-->

- [ ] I have ensured `make check test` passes

**How to verify it**

<!--
Describe how to test this, which examples to run to verify it, or anything
else that would be helpful to folks exploring this work
-->

**Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
**- A picture of a cute animal (not mandatory but encouraged)**

-->
