### PR TITLE
Adding the class and function for listing undeployed vercel commits

### DIFF
--- a/deploybot-ts/baml_src/vercel.baml
+++ b/deploybot-ts/baml_src/vercel.baml
@@ -14,6 +14,11 @@ class IntentListVercelDeployments {
     intent "list_vercel_deployments" @description("list the vercel deployments")
 }
 
+class IntentListUndeployedVercelCommits {
+    intent "list_undeployed_vercel_commits" @description("list commits that haven't been deployed to vercel yet")
+    limit int? @description("the number of commits to check, default is 20")
+}
+
 class IntentPromoteVercelDeployment {
     intent "promote_vercel_deployment" @description("promote a vercel deployment")
     vercel_deployment VercelDeployment @description("the vercel deployment to promote")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/humanlayer/humanlayer/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:

-->

**What I did**

1. Adding deploybot the functionality of listing undeployed vercel commits.

<!--
A succint description of the user-facing changes, at most 2-3 bullet points.
Less about the code changes that happened, more about the outcomes this work drives
-->

**How I did it**

1. Added the `IntentListUndeployedVercelCommits` class to vercel.baml
2. Added the case to agents.ts

<!--
Describe the work you did, tests you ran, changes you made, etc
-->

- [X] I have ensured `make check test` passes

**How to verify it**

<!--
Describe how to test this, which examples to run to verify it, or anything
else that would be helpful to folks exploring this work
-->

=> write @<bot>, list me undeployed vercel commits or similar.

**Description for the changelog**

Adding deploybot the functionality of listing undeployed vercel commits.

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
